### PR TITLE
Bash | Чижов Антон

### DIFF
--- a/Bash/REPL.ml
+++ b/Bash/REPL.ml
@@ -1,0 +1,43 @@
+(** Copyright 2021-2022, Chizhov Anton *)
+
+(** SPDX-License-Identifier: LGPL-3.0-or-later *)
+
+open Base
+open Bash_lib
+open Ast
+open Interpret.Interpret (Interpret.Result)
+
+type mode =
+  | DEBUG
+  | RELEASE
+
+type opts = { mutable mode : mode }
+
+let rec run_single ~opts ?(env = default_env) () =
+  let input = Stdio.In_channel.(input_all stdin) |> String.rstrip in
+  match Parser.parse input with
+  | Error e -> Caml.Format.printf "Parsing error: %a\n%!" Parser.pp_error e
+  | Result.Ok ast ->
+    (match opts.mode with
+     | DEBUG -> Caml.Format.printf "Parsed result: %a\n%!" pp_script ast
+     | _ -> ());
+    (match eval ~env ast with
+     | Ok env ->
+       (match opts.mode with
+        | DEBUG -> Caml.Format.printf "Evaluated result: %a\n%!" pp_environment env
+        | _ -> ());
+       run_single ~opts ~env ()
+     | Error e -> Caml.Format.printf "Interpretation error: %s" e)
+;;
+
+let () =
+  let opts = { mode = RELEASE } in
+  let open Caml.Arg in
+  parse
+    [ "-debug", Unit (fun () -> opts.mode <- DEBUG), "Start bash in debug mode" ]
+    (fun _ ->
+      Caml.Format.eprintf "Positioned arguments are not supported\n";
+      Caml.exit 1)
+    "Read-Eval-Print-Loop for Bash inerpreter";
+  run_single ~opts ()
+;;

--- a/Bash/demos/demoInterpret.ml
+++ b/Bash/demos/demoInterpret.ml
@@ -8,15 +8,13 @@ open Parser
 let interpret script =
   let open Interpret.Interpret (Interpret.Result) in
   match eval script with
-  | Ok env -> pp_environment Format.std_formatter env
+  | Ok env -> Printf.printf "Interpretation finished with return code: %d" env.retcode
   | Error e -> Printf.printf "Interpretation error: %s" e
 ;;
 
 let parse_and_interpret s =
   match Parser.parse s with
-  | Ok script ->
-    Format.printf "%a\n%!" Ast.pp_script script;
-    interpret script
+  | Ok script -> interpret script
   | Error e -> pp_error Format.std_formatter e
 ;;
 

--- a/Bash/demos/interpretTests.t
+++ b/Bash/demos/interpretTests.t
@@ -1,0 +1,253 @@
+External executable call
+  $ cat <<-"EOF" >another_script.sh
+  > echo "hello from another script"
+  > EOF
+  $ ./demoInterpret.exe <<-"EOF"
+  > echo $( ./another_script.sh )
+  > EOF
+  hello from another script
+  Interpretation finished with return code: 0
+
+Pipelines and redirections:
+(1) echo's output is redirected to the first cat's input
+(2) the first cat prints its input to testfile
+(3) the second cat gets nothing on its stdin as everything was printed to testfile
+  $ ./demoInterpret.exe <<-"EOF"
+  > echo printing | cat >testfile | cat
+  > EOF
+  Interpretation finished with return code: 0
+The first echo call doesn't print to stdout but writes to testfile
+  $ ./demoInterpret.exe <<-"EOF"
+  > cat <testfile
+  > echo appending >>testfile
+  > EOF
+  printing
+  Interpretation finished with return code: 0
+
+The second echo call doesn't print to stdout but appends to testfile
+  $ ./demoInterpret.exe <<-"EOF"
+  > cat <testfile
+  > EOF
+  printing
+  appending
+  Interpretation finished with return code: 0
+cat receives an argument (which is not yet supported) and produces a error message which
+is redirected from stderr to another_testfile (return code 1 is intentional)
+  $ ./demoInterpret.exe <<-"EOF"
+  > cat some_nonexistent_file >another_testfile 2>&1
+  > EOF
+  Interpretation finished with return code: 1
+Another cat call shows the contents of another_testfile that were produced by the previous
+cat call
+  $ ./demoInterpret.exe <<-"EOF"
+  > cat <another_testfile
+  > EOF
+  cat: some_nonexistent_file: No such file or directory
+  Interpretation finished with return code: 0
+
+Quoting
+  $ ./demoInterpret.exe <<-"EOF"
+  > echo "$( echo this should be a command substitution )"
+  > echo "\$( echo this should be just a string in parentheses )"
+  > echo '$( echo this should be just a string in parentheses too )'
+  > echo -------------------
+  > X="$((2 + 2))"
+  > echo "X equals $X"
+  > echo "X doesn't equal \$X"
+  > echo 'X does not equal $X neither'
+  > EOF
+  this should be a command substitution
+  $( echo this should be just a string in parentheses )
+  $( echo this should be just a string in parentheses too )
+  -------------------
+  X equals 4
+  X doesn't equal $X
+  X does not equal $X neither
+  Interpretation finished with return code: 0
+
+Pipeline lists: with && the left side is computed only if the left side is true, with
+|| the right side is computed only if the left side is false
+  $ ./demoInterpret.exe <<-"EOF"
+  > (( 2 > 3 )) && echo should not be printed
+  > (( 2 > 3 )) || echo should be printed 1
+  > (( 2 < 3 )) && echo should be printed 2
+  > (( 2 < 3 )) || echo should not be printed
+  > if (( 2 > 3 )) || (( 2 + 2 = 4 )) && (( 1 + 1 = 2 ))
+  > then echo should be printed 3
+  > else echo should not be printed
+  > fi
+  > EOF
+  should be printed 1
+  should be printed 2
+  should be printed 3
+  Interpretation finished with return code: 0
+
+While loop
+  $ ./demoInterpret.exe <<-"EOF"
+  > ABC=5
+  > while (( ABC < 10)); do
+  >   echo ABC equals $ABC
+  >   ABC=$(( ABC + 1 ))
+  > done
+  ABC equals 5
+  ABC equals 6
+  ABC equals 7
+  ABC equals 8
+  ABC equals 9
+  Interpretation finished with return code: 0
+
+For loop in another for loop
+  $ ./demoInterpret.exe <<-"EOF"
+  > for (( i = 0; i < 3; i = i + 1 )); do
+  >   for j in a b; do
+  >     echo i is $i and j is $j
+  >   done
+  > done
+  > EOF
+  i is 0 and j is a
+  i is 0 and j is b
+  i is 1 and j is a
+  i is 1 and j is b
+  i is 2 and j is a
+  i is 2 and j is b
+  Interpretation finished with return code: 0
+
+Pattern matching
+  $ ./demoInterpret.exe <<-"EOF"
+  > case bash in
+  >   sh | zch | fish) echo wrong shell;;
+  >   ?sh) echo wrong as bash has two letters before sh;;
+  >   [c-z]?sh) echo wrong as bash starts with b;;
+  >   [a-c]?s*) echo right;;
+  >   *) echo wrong as the previous one was true;;
+  >   esac
+  > EOF
+  right
+  Interpretation finished with return code: 0
+
+Functions with parameters:
+1) Recursive factorial computation
+  $ ./demoInterpret.exe <<-"EOF"
+  > function factorial() {
+  >   n=$1
+  >   if (( n <= 1 )); then
+  >     echo 1
+  >   else
+  >     last=$( factorial $(( n - 1 )) )
+  >     echo $(( n * last ))
+  >   fi
+  > }
+  > factorial 5
+  > EOF
+  120
+  Interpretation finished with return code: 0
+
+2) Iterative fibonacci series computation
+  $ ./demoInterpret.exe <<-"EOF"
+  > frst=0
+  > scnd=1
+  > function fib {
+  >   a=$frst
+  >   b=$scnd
+  >   n=$1
+  >   echo $a
+  >   for (( i = 1; i < n; i = i + 1 )); do
+  >     a=$(( a + b ))
+  >     echo $a
+  >     b=$(( a - b ))
+  >   done
+  > }
+  > fib 10
+  > EOF
+  0
+  1
+  1
+  2
+  3
+  5
+  8
+  13
+  21
+  34
+  Interpretation finished with return code: 0
+
+Variables
+  $ ./demoInterpret.exe <<-"EOF"
+  > X="first value"
+  > echo $X
+  > X="second value"
+  > echo $X
+  > X=(now it is "an array")
+  > echo "the third value is" ${X[3]}
+  > echo "the zero value is" $X
+  > X[10]="let's assign it another value"
+  > echo "and here it is:"  ${X[10]}
+  > echo -------------------
+  > function echo_Y () { echo "Y equals \"$Y\"" }
+  > Y="this will only be visible in this command call" echo_Y
+  > echo "Y equals \"$Y\""
+  > Z="and this won't be visible here" echo "Z equals \"$Z\""
+  > EOF
+  first value
+  second value
+  the third value is an array
+  the zero value is now
+  and here it is: let's assign it another value
+  -------------------
+  Y equals "this will only be visible in this command call"
+  Y equals ""
+  Z equals ""
+  Interpretation finished with return code: 0
+
+Expansions
+  $ touch a_file_with_a_rare_name.abacab a_file_with_another_rare_name.abacab
+  $ ./demoInterpret.exe <<-"EOF"
+  > echo brace expansion 1: prefix{_1_,_2_,_3_}postfix
+  > echo brace expansion 2: a{2..-3..2}b
+  > echo brace expansion 3: {e..a..-1}sh
+  > echo -------------------
+  > X=something-long
+  > echo parameter expansion: $X ${#X} ${X:2+2:10/2} ${X#s*e} ${X//?o/_} ...
+  > echo -------------------
+  > echo command substitution 1: $(echo result 1)
+  > echo command substitution 2: `echo result 2`
+  > echo -------------------
+  > X=3
+  > echo arithmetic expansion: $(( 9 * 5 - X ))
+  > echo -------------------
+  > EOF
+  brace expansion 1: prefix_1_postfix prefix_2_postfix prefix_3_postfix
+  brace expansion 2: a2b a0b a-2b
+  brace expansion 3: esh dsh csh bsh ash
+  -------------------
+  parameter expansion: something-long 14 thing thing-long _mething-_ng ...
+  -------------------
+  command substitution 1: result 1
+  command substitution 2: result 2
+  -------------------
+  arithmetic expansion: 42
+  -------------------
+  Interpretation finished with return code: 0
+
+Arrays: indexed and associative
+  $ ./demoInterpret.exe <<-"EOF"
+  > IND_ARR=(1 2 abc)
+  > echo ${IND_ARR[0]}
+  > echo ${IND_ARR[1]}
+  > echo ${IND_ARR[2]}
+  > echo -------------------
+  > ASSOC_ARR=(num=123 key=word)
+  > echo ${ASSOC_ARR[num]}
+  > echo ${ASSOC_ARR[key]}
+  > echo -------------------
+  > echo $(( ASSOC_ARR[num] + IND_ARR[1] ))
+  > EOF
+  1
+  2
+  abc
+  -------------------
+  123
+  word
+  -------------------
+  125
+  Interpretation finished with return code: 0

--- a/Bash/demos/interpretVanillaBashTest.t
+++ b/Bash/demos/interpretVanillaBashTest.t
@@ -1,0 +1,167 @@
+Set variable k to local environment
+  $ ./demoInterpret.exe <<-"EOF"
+  > k=1 echo hello
+  > echo k=$k
+  > EOF
+  hello
+  k=
+  Interpretation finished with return code: 0
+
+  $ bash <<-"EOF"
+  > k=1 echo hello
+  > echo k=$k
+  > EOF
+  hello
+  k=
+
+Set several global variables
+  $ ./demoInterpret.exe <<-"EOF"
+  > c=27 b=10
+  > echo c=$c b=$b
+  > EOF
+  c=27 b=10
+  Interpretation finished with return code: 0
+
+  $ bash <<-"EOF"
+  > c=27 b=10
+  > echo c=$c b=$b
+  > EOF
+  c=27 b=10
+
+Set global variables in pipe and use this variables in operand
+  $ ./demoInterpret.exe <<-"EOF"
+  > a=10 && echo $a | cat
+  > echo a=$a
+  > EOF
+  10
+  a=10
+  Interpretation finished with return code: 0
+
+  $ bash <<-"EOF"
+  > a=10 && echo $a | cat
+  > echo a=$a
+  > EOF
+  10
+  a=10
+
+Only variables from the first operand will be exposed
+to the global environment
+  $ ./demoInterpret.exe <<-"EOF"
+  > c=27 || e=28 && b=29 | e=2 && echo some
+  > echo c=$c b=$b e=$e
+  > EOF
+  some
+  c=27 b= e=
+  Interpretation finished with return code: 0
+
+  $ bash <<-"EOF"
+  > c=27 || e=28 && b=29 | e=2 && echo some
+  > echo c=$c b=$b e=$e
+  some
+  c=27 b= e=
+
+Check the correct operation of the logical or:
+the return code of any assignment is 0
+-> the right side of the boolean operand or will never be executed
+  $ ./demoInterpret.exe <<-"EOF"
+  > c=27 || e=28 && echo hello | f=2 && echo some
+  > echo c=$c e=$e f=$f
+  > EOF
+  some
+  c=27 e= f=
+  Interpretation finished with return code: 0
+
+  $ bash <<-"EOF"
+  > c=27 || e=28 && echo hello | f=2 && echo some
+  > echo c=$c e=$e f=$f
+  some
+  c=27 e= f=
+
+Сhecking the correct operation of the pipes
+  $ ./demoInterpret.exe <<-"EOF"
+  > c=27 && echo hello | cat
+  > echo c=$c
+  > EOF
+  hello
+  c=27
+  Interpretation finished with return code: 0
+
+  $ bash <<-"EOF"
+  > c=27 && echo hello | cat
+  > echo c=$c
+  > EOF
+  hello
+  c=27
+
+Set several variables to global environment in first operand
+  $ ./demoInterpret.exe <<-"EOF"
+  > c=27 && d=28 && echo hello | cat
+  > echo c=$c d=$d
+  > EOF
+  hello
+  c=27 d=28
+  Interpretation finished with return code: 0
+
+  $ bash <<-"EOF"
+  > c=27 && d=28 && echo hello | cat
+  > echo c=$c d=$d
+  > EOF
+  hello
+  c=27 d=28
+
+Set several variables to global environment in second operand
+  $ ./demoInterpret.exe <<-"EOF"
+  > b=10 | c=27 && echo hello | cat
+  > echo b=$b c=$c
+  > EOF
+  hello
+  b= c=
+  Interpretation finished with return code: 0
+
+  $ bash <<-"EOF"
+  > b=10 | c=27 && echo hello | cat
+  > echo b=$b c=$c
+  > EOF
+  hello
+  b= c=
+
+In this test we are trying to override the value for a variable (e)
+  $ ./demoInterpret.exe <<-"EOF"
+  > c=27 && e=28 && echo hello | e=2 || d=10
+  > echo c=$c e=$e d=$d
+  > EOF
+  c=27 e=28 d=
+  Interpretation finished with return code: 0
+
+  $ bash <<-"EOF"
+  > c=27 && e=28 && echo hello | e=2 || d=10
+  > echo c=$c e=$e d=$d
+  > EOF
+  c=27 e=28 d=
+
+Test or operator (||) with variable assignment
+  $ ./demoInterpret.exe <<-"EOF"
+  > c=27 || e=28 && echo hello | e=2
+  > echo c=$c e=$e
+  > EOF
+  c=27 e=
+  Interpretation finished with return code: 0
+
+  $ bash <<-"EOF"
+  > c=27 || e=28 && echo hello | e=2
+  > echo c=$c e=$e
+  > EOF
+  c=27 e=
+
+Test or opeator (||) with cmd
+  $ ./demoInterpret.exe <<-"EOF"
+  > c=27 || e=28 && echo hello | f=2 || echo some
+  > echo c=$c e=$e f=$f
+  > EOF
+  c=27 e= f=
+  Interpretation finished with return code: 0
+
+  $ bash <<-"EOF"
+  > c=27 || e=28 && echo hello | f=2 || echo some
+  > echo c=$c e=$e f=$f
+  c=27 e= f=

--- a/Bash/demos/parsingTests.t
+++ b/Bash/demos/parsingTests.t
@@ -1,4 +1,4 @@
-Copyright 2021-2022, Kakadu and contributors
+(** Copyright 2021-2022, Chizhov Anton *)
 SPDX-License-Identifier: CC0-1.0
 
 Tests about parsing go here. It's expected that programs parse something and

--- a/Bash/dune
+++ b/Bash/dune
@@ -5,3 +5,12 @@
  (release
   (flags
    (:standard -warn-error -A -w -58))))
+
+(executable
+ (name REPL)
+ (public_name REPL)
+ (modules REPL)
+ (libraries Bash.Lib stdio))
+
+(cram
+ (deps ./REPL.exe %{bin:REPL}))

--- a/Bash/lib/ast.ml
+++ b/Bash/lib/ast.ml
@@ -1,4 +1,4 @@
-(** Copyright 2021-2022, Kakadu and contributors *)
+(** Copyright 2021-2022, Chizhov Anton *)
 
 (** SPDX-License-Identifier: LGPL-3.0-or-later *)
 

--- a/Bash/lib/dune
+++ b/Bash/lib/dune
@@ -2,7 +2,7 @@
  (name bash_lib)
  (public_name Bash.Lib)
  (modules Ast Interpret Parser utils)
- (libraries base angstrom unix batteries)
+ (libraries base angstrom unix re batteries)
  (preprocess
   (pps ppx_expect ppx_fields_conv ppx_deriving.show ppx_variants_conv))
  (inline_tests))

--- a/Bash/lib/interpret.ml
+++ b/Bash/lib/interpret.ml
@@ -91,7 +91,9 @@ module Interpret (M : MonadFail) = struct
     IntMap.iter
       (fun n fd ->
         match n with
-        | 0 | 1 | 2 -> dup2 fd (num_to_std_fd n)
+        | 0 -> dup2 fd Unix.stdin
+        | 1 -> dup2 fd Unix.stdout
+        | 2 -> dup2 fd Unix.stderr
         | _ -> ())
       fds
   ;;
@@ -833,7 +835,8 @@ let test_ok, test_fail =
     | Ok script -> eval_impl script
     | Error e ->
       Parser.pp_error Format.std_formatter e;
-      failwith "Error while parsing test input (assuming the test gets the correct input)"
+      Result.fail
+        "Error while parsing test input (assuming the test gets the correct input)"
   in
   let ok ?(local_vars = StrMap.empty) ?(global_vars = StrMap.empty) ?(retcode = 0) input =
     match test_inner input with

--- a/Bash/lib/interpret.ml
+++ b/Bash/lib/interpret.ml
@@ -1,4 +1,4 @@
-(** Copyright 2021-2022, Kakadu and contributors *)
+(** Copyright 2021-2022, Chizhov Anton *)
 
 (** SPDX-License-Identifier: LGPL-3.0-or-later *)
 

--- a/Bash/lib/interpret.mli
+++ b/Bash/lib/interpret.mli
@@ -1,4 +1,4 @@
-(** Copyright 2021-2022, Kakadu and contributors *)
+(** Copyright 2021-2022, Chizhov Anton *)
 
 (** SPDX-License-Identifier: LGPL-3.0-or-later *)
 

--- a/Bash/lib/interpret.mli
+++ b/Bash/lib/interpret.mli
@@ -43,5 +43,6 @@ module Interpret (M : MonadFail) : sig
     }
   [@@deriving show { with_path = false }]
 
-  val eval : script -> environment M.t
+  val default_env : environment
+  val eval : ?env:environment -> script -> environment M.t
 end

--- a/Bash/lib/parser.ml
+++ b/Bash/lib/parser.ml
@@ -1,4 +1,4 @@
-(** Copyright 2021-2022, Kakadu and contributors *)
+(** Copyright 2021-2022, Chizhov Anton *)
 
 (** SPDX-License-Identifier: LGPL-3.0-or-later *)
 

--- a/Bash/lib/utils.ml
+++ b/Bash/lib/utils.ml
@@ -8,6 +8,34 @@ let all_pred preds el = List.for_all (fun fn -> fn el) preds
 (* computes diff between l1 and l2 *)
 let diff l1 l2 = List.filter (fun x -> not (List.mem x l2)) l1
 
+(* info about standard dile descriptors *)
+
+(* standard file descriptors (for writing more readable code) *)
+type std_fd =
+  | StdIn
+  | StdOut
+  | StdErr
+
+let fd_to_int = function
+  | StdIn -> 0
+  | StdOut -> 1
+  | StdErr -> 2
+;;
+
+(* order is important *)
+let std_fd_types = [ StdIn; StdOut; StdErr ]
+
+(* function-resolver for default std descriptors *)
+let num_to_std_fd = function
+  | 0 -> Unix.stdin
+  | 1 -> Unix.stdout
+  | 2 -> Unix.stderr
+  | _ -> failwith "Cannot resolve fd"
+;;
+
+(* List of standart fds *)
+let std_fds = List.map (fun x -> num_to_std_fd (fd_to_int x)) std_fd_types
+
 (* structures *)
 
 module IntMap = struct

--- a/Bash/lib/utils.ml
+++ b/Bash/lib/utils.ml
@@ -22,19 +22,8 @@ let fd_to_int = function
   | StdErr -> 2
 ;;
 
-(* order is important *)
-let std_fd_types = [ StdIn; StdOut; StdErr ]
-
-(* function-resolver for default std descriptors *)
-let num_to_std_fd = function
-  | 0 -> Unix.stdin
-  | 1 -> Unix.stdout
-  | 2 -> Unix.stderr
-  | _ -> failwith "Cannot resolve fd"
-;;
-
 (* List of standart fds *)
-let std_fds = List.map (fun x -> num_to_std_fd (fd_to_int x)) std_fd_types
+let std_fds = [ Unix.stdin; Unix.stdout; Unix.stderr ]
 
 (* structures *)
 

--- a/Bash/lib/utils.mli
+++ b/Bash/lib/utils.mli
@@ -20,12 +20,6 @@ type std_fd =
 (* get int by standard file descriptor *)
 val fd_to_int : std_fd -> int
 
-(* order is important *)
-val std_fd_types : std_fd list
-
-(* function-resolver for default std descriptors *)
-val num_to_std_fd : int -> Unix.file_descr
-
 (* List of standart fds *)
 val std_fds : Unix.file_descr list
 

--- a/Bash/lib/utils.mli
+++ b/Bash/lib/utils.mli
@@ -11,6 +11,24 @@ val all_pred : ('a -> bool) list -> 'a -> bool
 (* Computes diff between l1 and l2 *)
 val diff : 'a list -> 'a list -> 'a list
 
+(* standard file descriptors (for writing more readable code) *)
+type std_fd =
+  | StdIn (* 0 *)
+  | StdOut (* 1 *)
+  | StdErr (* 2 *)
+
+(* get int by standard file descriptor *)
+val fd_to_int : std_fd -> int
+
+(* order is important *)
+val std_fd_types : std_fd list
+
+(* function-resolver for default std descriptors *)
+val num_to_std_fd : int -> Unix.file_descr
+
+(* List of standart fds *)
+val std_fds : Unix.file_descr list
+
 (* Map with string keys *)
 module StrMap : sig
   include Map.S with type key = string


### PR DESCRIPTION
Вторая часть Bash'a.
В этом пре было сделано:
* запуск файлов-скриптов
* обработка `redirection`'ов
* `REPL` (неполноценный*)
* добавлена обработка `expansion`'ов: 
1. `substring`
2. `substring removal`
3. `substitution`
* добавлена корректная обработка переменных окружения (в баше она странная, поэтому код получился подзапутанный с использованием флагов, см. объяснение в функции `eval_pipes`, которое было добавлено ещё в прошлом `PR`e)
* добавлена обработка `redirection`'ов
* добавлена обработка `case in`.
* исправлены небольшие баги

*) В данный момент `REPL` ожидает после ввода новой команды/функции `Ctrl+D`, а не пробел. Можно поправить и сделать репл в более правильном виде, но может быть и так можно оставить.

И ещё Вы предлагали написать тесты с использованием ванильного баша ([см прошлый PR](https://github.com/Kakadu/fp2022/pull/10#discussion_r1014416088)). Можно ли ограничиться тестами для пайпов, которые проверяют ту логику обработки операндов, которую я описывал в функции `eval_pipes`?

Также хотелось бы получить ревью к текущей реализации, после чего я добавлю коммит с исправлением репла (если это нужно), тестами с ванильным башем и исправления замечаний к коммитам.
Также если я ещё что-то забыл, то также добавлю. (напишите, если что-то ещё необходимо реализовать)